### PR TITLE
feat: add Dockerfile, Terraform infrastructure, and GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,72 @@
+name: CI
+
+on:
+  workflow_call:
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.claude/**'
+      - 'terraform/**'
+      - 'e2e-tests/**'
+      - '.pre-commit-config.yaml'
+      - '.markdownlint.yaml'
+      - '.gitignore'
+      - 'LICENSE'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+
+      - name: Build and test
+        run: ./mvnw verify -B
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: |
+            target/surefire-reports/
+            target/site/jacoco/
+
+  docker-build-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image (smoke test)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: petclinic:smoke-test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,188 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Docker image tag to deploy (leave empty to build fresh)'
+        required: false
+        type: string
+      skip_tests:
+        description: 'Skip CI and E2E tests (emergency deploys only)'
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: deploy-staging-bt
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  ci:
+    uses: ./.github/workflows/ci.yml
+    if: ${{ !inputs.skip_tests }}
+
+  e2e:
+    uses: ./.github/workflows/e2e-tests.yml
+    if: ${{ !inputs.skip_tests }}
+
+  build-and-push:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+    needs: [ci, e2e]
+    if: |
+      always() &&
+      !cancelled() &&
+      (needs.ci.result == 'success' || needs.ci.result == 'skipped') &&
+      (needs.e2e.result == 'success' || needs.e2e.result == 'skipped') &&
+      github.event.inputs.image_tag == ''
+    timeout-minutes: 20
+    outputs:
+      image_tag: ${{ steps.image-tag.outputs.image_tag }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN_DEPLOY_BT }}
+          aws-region: ${{ vars.AWS_REGION_BT }}
+
+      - name: Login to Amazon ECR
+        id: ecr-login
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.ecr-login.outputs.registry }}/${{ vars.ECR_REPOSITORY_BT }}
+          tags: |
+            type=sha,prefix=sha-,format=short
+
+      - name: Capture immutable image tag
+        id: image-tag
+        run: echo "image_tag=sha-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  terraform:
+    name: Terraform apply
+    runs-on: ubuntu-latest
+    needs: [ci, e2e, build-and-push]
+    if: |
+      always() &&
+      !cancelled() &&
+      (needs.ci.result == 'success' || needs.ci.result == 'skipped') &&
+      (needs.e2e.result == 'success' || needs.e2e.result == 'skipped') &&
+      (needs.build-and-push.result == 'success' || github.event.inputs.image_tag != '')
+    outputs:
+      image_tag: ${{ steps.resolve.outputs.tag }}
+      full_image: ${{ steps.resolve.outputs.full_image }}
+    timeout-minutes: 15
+
+    steps:
+      - name: Resolve image tag
+        id: resolve
+        env:
+          MANUAL_TAG: ${{ github.event.inputs.image_tag }}
+          BUILD_TAG: ${{ needs.build-and-push.outputs.image_tag }}
+          ECR_REGISTRY: ${{ vars.AWS_ACCOUNT_ID_BT }}.dkr.ecr.${{ vars.AWS_REGION_BT }}.amazonaws.com
+          ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY_BT }}
+        run: |
+          TAG="${MANUAL_TAG:-$BUILD_TAG}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "full_image=${ECR_REGISTRY}/${ECR_REPOSITORY}:${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Resolved image tag: ${TAG}"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN_DEPLOY_BT }}
+          aws-region: ${{ vars.AWS_REGION_BT }}
+
+      - name: Verify image exists in ECR
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.image_tag != '' }}
+        run: |
+          aws ecr describe-images \
+            --repository-name "${{ vars.ECR_REPOSITORY_BT }}" \
+            --image-ids imageTag="${{ steps.resolve.outputs.tag }}" \
+            --region "${{ vars.AWS_REGION_BT }}" >/dev/null
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+
+      - name: Terraform init
+        working-directory: terraform
+        run: |
+          terraform init -input=false \
+            -backend-config="bucket=${{ secrets.TF_BACKEND_BUCKET_BT }}" \
+            -backend-config="key=${{ secrets.TF_BACKEND_KEY_BT }}" \
+            -backend-config="region=${{ vars.AWS_REGION_BT }}"
+
+      - name: Terraform apply
+        working-directory: terraform
+        env:
+          TF_VAR_container_image: ${{ steps.resolve.outputs.full_image }}
+          TF_VAR_aws_region: ${{ vars.AWS_REGION_BT }}
+        run: terraform apply -input=false -auto-approve
+
+  deploy-ecs:
+    name: Deploy to ECS
+    runs-on: ubuntu-latest
+    needs: [terraform]
+    timeout-minutes: 15
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN_DEPLOY_BT }}
+          aws-region: ${{ vars.AWS_REGION_BT }}
+
+      - name: Download current task definition
+        run: |
+          aws ecs describe-task-definition \
+            --task-definition ${{ vars.ECS_TASK_FAMILY_BT }} \
+            --query 'taskDefinition' \
+            --output json > task-definition.json
+
+      - name: Render new task definition
+        id: render
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: task-definition.json
+          container-name: ${{ vars.ECS_TASK_FAMILY_BT }}
+          image: ${{ needs.terraform.outputs.full_image }}
+
+      - name: Deploy to ECS
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        with:
+          task-definition: ${{ steps.render.outputs.task-definition }}
+          service: ${{ vars.ECS_SERVICE_BT }}
+          cluster: ${{ vars.ECS_CLUSTER_BT }}
+          wait-for-service-stability: true

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,6 +1,7 @@
 name: E2E Tests
 
 on:
+  workflow_call:
   pull_request:
   push:
     branches:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,92 @@
+name: Terraform
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'Terraform action to perform'
+        required: true
+        type: choice
+        options:
+          - plan
+          - apply
+          - destroy
+
+concurrency:
+  group: deploy-staging-bt
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  terraform:
+    name: Terraform ${{ github.event.inputs.action }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN_DEPLOY_BT }}
+          aws-region: ${{ vars.AWS_REGION_BT }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+
+      - name: Terraform init
+        working-directory: terraform
+        run: |
+          terraform init -input=false \
+            -backend-config="bucket=${{ secrets.TF_BACKEND_BUCKET_BT }}" \
+            -backend-config="key=${{ secrets.TF_BACKEND_KEY_BT }}" \
+            -backend-config="region=${{ vars.AWS_REGION_BT }}"
+
+      - name: Resolve and verify image tag
+        id: image-tag
+        env:
+          ECR_REGISTRY: ${{ vars.AWS_ACCOUNT_ID_BT }}.dkr.ecr.${{ vars.AWS_REGION_BT }}.amazonaws.com
+          ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY_BT }}
+        run: |
+          TAG="sha-${GITHUB_SHA::7}"
+          echo "Verifying image ${TAG} exists in ECR..."
+          aws ecr describe-images \
+            --repository-name "${ECR_REPOSITORY}" \
+            --image-ids imageTag="${TAG}" \
+            --region "${{ vars.AWS_REGION_BT }}" >/dev/null || {
+            echo "ERROR: Image ${TAG} not found in ECR. Run the deploy pipeline first to build and push the image." >&2
+            exit 1
+          }
+          echo "full_image=${ECR_REGISTRY}/${ECR_REPOSITORY}:${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Resolved and verified image: ${ECR_REGISTRY}/${ECR_REPOSITORY}:${TAG}"
+
+      - name: Terraform plan
+        if: github.event.inputs.action == 'plan'
+        working-directory: terraform
+        env:
+          TF_VAR_container_image: ${{ steps.image-tag.outputs.full_image }}
+          TF_VAR_aws_region: ${{ vars.AWS_REGION_BT }}
+        run: terraform plan -input=false
+
+      - name: Terraform apply
+        if: github.event.inputs.action == 'apply'
+        working-directory: terraform
+        env:
+          TF_VAR_container_image: ${{ steps.image-tag.outputs.full_image }}
+          TF_VAR_aws_region: ${{ vars.AWS_REGION_BT }}
+        run: terraform apply -input=false -auto-approve
+
+      - name: Terraform destroy
+        if: github.event.inputs.action == 'destroy'
+        working-directory: terraform
+        env:
+          TF_VAR_container_image: ${{ steps.image-tag.outputs.full_image }}
+          TF_VAR_aws_region: ${{ vars.AWS_REGION_BT }}
+        run: terraform destroy -input=false -auto-approve

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+# Stage 1: Build
+FROM eclipse-temurin:17-jdk-jammy AS builder
+
+WORKDIR /workspace
+
+COPY .mvn/ .mvn/
+COPY mvnw pom.xml ./
+RUN chmod +x mvnw && ./mvnw dependency:go-offline -B
+
+COPY checkstyle.xml ./
+COPY src/ src/
+RUN ./mvnw package -DskipTests -B
+RUN java -Djarmode=tools -jar target/*.jar extract --layers --launcher --destination target/extracted
+
+# Stage 2: Runtime
+FROM eclipse-temurin:17-jre-jammy AS runtime
+
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/* \
+    && addgroup --system spring && adduser --system --ingroup spring spring
+
+WORKDIR /app
+
+COPY --from=builder /workspace/target/extracted/dependencies/ ./
+COPY --from=builder /workspace/target/extracted/spring-boot-loader/ ./
+COPY --from=builder /workspace/target/extracted/snapshot-dependencies/ ./
+COPY --from=builder /workspace/target/extracted/application/ ./
+
+USER spring:spring
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=60s --retries=3 \
+  CMD curl -f http://localhost:8080/actuator/health || exit 1
+
+ENTRYPOINT ["java", "-XX:+UseContainerSupport", "-XX:MaxRAMPercentage=75.0", "org.springframework.boot.loader.launch.JarLauncher"]

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,45 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.8.1"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:u8AKlWVDTH5r9YLSeswoVEjiY72Rt4/ch7U+61ZDkiQ=",
+    "zh:08dd03b918c7b55713026037c5400c48af5b9f468f483463321bd18e17b907b4",
+    "zh:0eee654a5542dc1d41920bbf2419032d6f0d5625b03bd81339e5b33394a3e0ae",
+    "zh:229665ddf060aa0ed315597908483eee5b818a17d09b6417a0f52fd9405c4f57",
+    "zh:2469d2e48f28076254a2a3fc327f184914566d9e40c5780b8d96ebf7205f8bc0",
+    "zh:37d7eb334d9561f335e748280f5535a384a88675af9a9eac439d4cfd663bcb66",
+    "zh:741101426a2f2c52dee37122f0f4a2f2d6af6d852cb1db634480a86398fa3511",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:a902473f08ef8df62cfe6116bd6c157070a93f66622384300de235a533e9d4a9",
+    "zh:b85c511a23e57a2147355932b3b6dce2a11e856b941165793a0c3d7578d94d05",
+    "zh:c5172226d18eaac95b1daac80172287b69d4ce32750c82ad77fa0768be4ea4b8",
+    "zh:dab4434dba34aad569b0bc243c2d3f3ff86dd7740def373f2a49816bd2ff819b",
+    "zh:f49fd62aa8c5525a5c17abd51e27ca5e213881d58882fd42fec4a545b53c9699",
+  ]
+}

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket       = "PLACEHOLDER"
+    key          = "PLACEHOLDER"
+    region       = "us-east-1"
+    use_lockfile = true
+    encrypt      = true
+  }
+}

--- a/terraform/bootstrap/.terraform.lock.hcl
+++ b/terraform/bootstrap/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/terraform/bootstrap/backend.tf.example
+++ b/terraform/bootstrap/backend.tf.example
@@ -1,0 +1,14 @@
+# WARNING: Update bucket and region below to match the values output by your bootstrap apply
+# before copying this file to backend.tf and running: terraform init -migrate-state
+# Copy to backend.tf after initial apply, then run: terraform init -migrate-state
+# Bucket name pattern: {project_name}-{environment}-tfstate
+# To destroy: remove backend.tf, run terraform init -migrate-state, then terraform destroy
+terraform {
+  backend "s3" {
+    bucket       = "petclinic-bt-staging-tfstate"
+    key          = "bootstrap/terraform.tfstate"
+    region       = "us-east-1"
+    use_lockfile = true
+    encrypt      = true
+  }
+}

--- a/terraform/bootstrap/bootstrap.sh
+++ b/terraform/bootstrap/bootstrap.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Bootstrap script: creates S3 state bucket, OIDC provider, IAM deploy role,
+# and ECR repository via Terraform, then migrates local state into the S3 bucket.
+#
+# Usage: cd terraform/bootstrap && ./bootstrap.sh
+#
+# Teardown: remove backend.tf, run terraform init -migrate-state, then terraform destroy
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${SCRIPT_DIR}"
+
+echo "==> Step 1: Initialise Terraform with local state"
+terraform init
+
+echo ""
+echo "==> Applying bootstrap resources (S3 bucket + OIDC provider + IAM role)"
+terraform apply
+
+echo ""
+echo "==> Step 2: Migrate local state to S3"
+echo "    Copy the example backend config and run init -migrate-state:"
+echo ""
+echo "    cp backend.tf.example backend.tf"
+echo "    terraform init -migrate-state"
+echo ""
+read -r -p "Press Enter after copying backend.tf.example to backend.tf, or Ctrl-C to do it manually later..."
+
+if [ ! -f backend.tf ]; then
+  echo "ERROR: backend.tf not found. Copy backend.tf.example to backend.tf and re-run:"
+  echo "  cp backend.tf.example backend.tf && terraform init -migrate-state"
+  exit 1
+fi
+
+terraform init -migrate-state
+
+echo ""
+echo "==> Bootstrap complete. Outputs:"
+terraform output
+
+echo ""
+echo "Next steps:"
+echo "  1. Set GitHub secret AWS_ROLE_ARN_DEPLOY_BT to the deploy_role_arn output above"
+echo "  2. Set GitHub secret TF_BACKEND_BUCKET_BT to the state_bucket_name output above"
+echo "  3. Set GitHub secret TF_BACKEND_KEY_BT to the desired state file key (e.g. petclinic/terraform.tfstate)"
+echo "  4. Set GitHub variable AWS_REGION_BT to your region (default: us-east-1)"
+echo "  5. Set GitHub variable AWS_ACCOUNT_ID_BT to your AWS account ID"
+echo "  6. Set GitHub variable ECR_REPOSITORY_BT to the ecr_repository_name output above"

--- a/terraform/bootstrap/locals.tf
+++ b/terraform/bootstrap/locals.tf
@@ -1,0 +1,12 @@
+locals {
+  name_prefix = "${var.project_name}-${var.environment}"
+
+  common_tags = {
+    Project     = var.project_name
+    Environment = var.environment
+    ManagedBy   = "terraform"
+  }
+
+  oidc_issuer_url = "https://token.actions.githubusercontent.com"
+  github_subject  = "repo:${var.github_repository}:ref:refs/heads/main"
+}

--- a/terraform/bootstrap/main.tf
+++ b/terraform/bootstrap/main.tf
@@ -1,0 +1,342 @@
+resource "aws_s3_bucket" "terraform_state" {
+  bucket = "${local.name_prefix}-tfstate"
+  tags   = merge(local.common_tags, { Name = "${local.name_prefix}-tfstate" })
+}
+
+resource "aws_s3_bucket_versioning" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+  versioning_configuration { status = "Enabled" }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+  rule {
+    apply_server_side_encryption_by_default { sse_algorithm = "AES256" }
+    bucket_key_enabled = true
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "terraform_state" {
+  bucket                  = aws_s3_bucket.terraform_state.id
+  block_public_acls       = true
+  ignore_public_acls      = true
+  block_public_policy     = true
+  restrict_public_buckets = true
+}
+
+resource "aws_iam_openid_connect_provider" "github_actions" {
+  url             = local.oidc_issuer_url
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = []
+
+  tags = merge(local.common_tags, { Name = "${local.name_prefix}-github-oidc" })
+}
+
+resource "aws_iam_role" "github_deploy" {
+  name = "${local.name_prefix}-github-deploy"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = aws_iam_openid_connect_provider.github_actions.arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringLike = {
+            "token.actions.githubusercontent.com:sub" = local.github_subject
+          }
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = merge(local.common_tags, { Name = "${local.name_prefix}-github-deploy" })
+}
+
+resource "aws_iam_role_policy" "github_deploy" {
+  name = "${local.name_prefix}-github-deploy-policy"
+  role = aws_iam_role.github_deploy.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "ECRAuth"
+        Effect   = "Allow"
+        Action   = "ecr:GetAuthorizationToken"
+        Resource = "*"
+      },
+      {
+        Sid    = "ECRImage"
+        Effect = "Allow"
+        Action = [
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:BatchGetImage",
+          "ecr:CompleteLayerUpload",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:InitiateLayerUpload",
+          "ecr:PutImage",
+          "ecr:UploadLayerPart",
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "ECRRepo"
+        Effect = "Allow"
+        Action = [
+          "ecr:DescribeImages",
+          "ecr:DescribeRepositories",
+          "ecr:GetLifecyclePolicy",
+          "ecr:GetRepositoryPolicy",
+          "ecr:ListTagsForResource",
+          "ecr:PutImageScanningConfiguration",
+          "ecr:PutLifecyclePolicy",
+          "ecr:SetRepositoryPolicy",
+          "ecr:TagResource",
+          "ecr:UntagResource",
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "S3State"
+        Effect = "Allow"
+        Action = [
+          "s3:DeleteObject",
+          "s3:GetObject",
+          "s3:PutObject",
+        ]
+        Resource = "${aws_s3_bucket.terraform_state.arn}/*"
+      },
+      {
+        Sid      = "S3StateBucket"
+        Effect   = "Allow"
+        Action   = "s3:ListBucket"
+        Resource = aws_s3_bucket.terraform_state.arn
+      },
+      {
+        Sid    = "ECS"
+        Effect = "Allow"
+        Action = [
+          "ecs:CreateCluster",
+          "ecs:CreateService",
+          "ecs:DeleteCluster",
+          "ecs:DeleteService",
+          "ecs:DeregisterTaskDefinition",
+          "ecs:DescribeClusters",
+          "ecs:DescribeServices",
+          "ecs:DescribeTaskDefinition",
+          "ecs:ListClusters",
+          "ecs:ListServices",
+          "ecs:ListTagsForResource",
+          "ecs:ListTaskDefinitions",
+          "ecs:RegisterTaskDefinition",
+          "ecs:TagResource",
+          "ecs:UntagResource",
+          "ecs:UpdateService",
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "EC2VPC"
+        Effect = "Allow"
+        Action = [
+          "ec2:AllocateAddress",
+          "ec2:AssociateRouteTable",
+          "ec2:AttachInternetGateway",
+          "ec2:AuthorizeSecurityGroupEgress",
+          "ec2:AuthorizeSecurityGroupIngress",
+          "ec2:CreateInternetGateway",
+          "ec2:CreateNatGateway",
+          "ec2:CreateRoute",
+          "ec2:CreateRouteTable",
+          "ec2:CreateSecurityGroup",
+          "ec2:CreateSubnet",
+          "ec2:CreateTags",
+          "ec2:CreateVpc",
+          "ec2:DeleteInternetGateway",
+          "ec2:DeleteNatGateway",
+          "ec2:DeleteRoute",
+          "ec2:DeleteRouteTable",
+          "ec2:DeleteSecurityGroup",
+          "ec2:DeleteSubnet",
+          "ec2:DeleteVpc",
+          "ec2:DescribeAddresses",
+          "ec2:DescribeAddressesAttribute",
+          "ec2:DescribeAvailabilityZones",
+          "ec2:DescribeInternetGateways",
+          "ec2:DescribeNatGateways",
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:DescribeRouteTables",
+          "ec2:DescribeSecurityGroupRules",
+          "ec2:DescribeSecurityGroups",
+          "ec2:DescribeSubnets",
+          "ec2:DescribeVpcAttribute",
+          "ec2:DescribeVpcs",
+          "ec2:DetachInternetGateway",
+          "ec2:DisassociateAddress",
+          "ec2:DisassociateRouteTable",
+          "ec2:ModifySubnetAttribute",
+          "ec2:ModifyVpcAttribute",
+          "ec2:ReleaseAddress",
+          "ec2:RevokeSecurityGroupEgress",
+          "ec2:RevokeSecurityGroupIngress",
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "RDS"
+        Effect = "Allow"
+        Action = [
+          "rds:AddTagsToResource",
+          "rds:CreateDBInstance",
+          "rds:CreateDBSubnetGroup",
+          "rds:DeleteDBInstance",
+          "rds:DeleteDBSubnetGroup",
+          "rds:DescribeDBInstances",
+          "rds:DescribeDBSubnetGroups",
+          "rds:ListTagsForResource",
+          "rds:ModifyDBInstance",
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "ALB"
+        Effect = "Allow"
+        Action = [
+          "elasticloadbalancing:AddTags",
+          "elasticloadbalancing:CreateListener",
+          "elasticloadbalancing:CreateLoadBalancer",
+          "elasticloadbalancing:CreateTargetGroup",
+          "elasticloadbalancing:DeleteListener",
+          "elasticloadbalancing:DeleteLoadBalancer",
+          "elasticloadbalancing:DeleteTargetGroup",
+          "elasticloadbalancing:DescribeListenerAttributes",
+          "elasticloadbalancing:DescribeListeners",
+          "elasticloadbalancing:DescribeLoadBalancerAttributes",
+          "elasticloadbalancing:DescribeLoadBalancers",
+          "elasticloadbalancing:DescribeTags",
+          "elasticloadbalancing:DescribeTargetGroupAttributes",
+          "elasticloadbalancing:DescribeTargetGroups",
+          "elasticloadbalancing:ModifyLoadBalancerAttributes",
+          "elasticloadbalancing:ModifyTargetGroupAttributes",
+          "elasticloadbalancing:RemoveTags",
+          "elasticloadbalancing:SetSecurityGroups",
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "IAMRoles"
+        Effect = "Allow"
+        Action = [
+          "iam:AttachRolePolicy",
+          "iam:CreateRole",
+          "iam:DeleteRole",
+          "iam:DeleteRolePolicy",
+          "iam:DetachRolePolicy",
+          "iam:GetRole",
+          "iam:GetRolePolicy",
+          "iam:ListAttachedRolePolicies",
+          "iam:ListInstanceProfilesForRole",
+          "iam:ListRolePolicies",
+          "iam:PassRole",
+          "iam:PutRolePolicy",
+          "iam:TagRole",
+          "iam:UntagRole",
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "SecretsManager"
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:CreateSecret",
+          "secretsmanager:DeleteSecret",
+          "secretsmanager:DescribeSecret",
+          "secretsmanager:GetRandomPassword",
+          "secretsmanager:GetResourcePolicy",
+          "secretsmanager:GetSecretValue",
+          "secretsmanager:ListSecretVersionIds",
+          "secretsmanager:PutSecretValue",
+          "secretsmanager:TagResource",
+          "secretsmanager:UntagResource",
+          "secretsmanager:UpdateSecret",
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "CloudWatchLogs"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:DeleteLogGroup",
+          "logs:DescribeLogGroups",
+          "logs:ListTagsForResource",
+          "logs:ListTagsLogGroup",
+          "logs:PutRetentionPolicy",
+          "logs:TagLogGroup",
+          "logs:TagResource",
+          "logs:UntagLogGroup",
+          "logs:UntagResource",
+        ]
+        Resource = "*"
+      },
+    ]
+  })
+}
+
+resource "aws_ecr_repository" "main" {
+  name                 = local.name_prefix
+  image_tag_mutability = "IMMUTABLE"
+  force_delete         = false
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = merge(local.common_tags, { Name = "${local.name_prefix}-ecr" })
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "main" {
+  repository = aws_ecr_repository.main.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Expire untagged images after 1 day"
+        selection = {
+          tagStatus   = "untagged"
+          countType   = "sinceImagePushed"
+          countUnit   = "days"
+          countNumber = 1
+        }
+        action = {
+          type = "expire"
+        }
+      },
+      {
+        rulePriority = 2
+        description  = "Keep last 10 tagged images"
+        selection = {
+          tagStatus     = "tagged"
+          tagPrefixList = ["sha-"]
+          countType     = "imageCountMoreThan"
+          countNumber   = 10
+        }
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+}

--- a/terraform/bootstrap/outputs.tf
+++ b/terraform/bootstrap/outputs.tf
@@ -1,0 +1,39 @@
+output "deploy_role_arn" {
+  description = "ARN of the GitHub Actions deploy role — set as GitHub secret AWS_ROLE_ARN_DEPLOY_BT"
+  value       = aws_iam_role.github_deploy.arn
+}
+
+output "deploy_role_name" {
+  description = "Name of the GitHub Actions deploy IAM role"
+  value       = aws_iam_role.github_deploy.name
+}
+
+output "oidc_provider_arn" {
+  description = "ARN of the GitHub Actions OIDC provider"
+  value       = aws_iam_openid_connect_provider.github_actions.arn
+}
+
+output "state_bucket_arn" {
+  description = "ARN of the S3 bucket used for Terraform state"
+  value       = aws_s3_bucket.terraform_state.arn
+}
+
+output "state_bucket_name" {
+  description = "Name of the S3 bucket used for Terraform state"
+  value       = aws_s3_bucket.terraform_state.bucket
+}
+
+output "ecr_repository_url" {
+  description = "Full ECR repository URI — use as the base image URL in deploy workflows"
+  value       = aws_ecr_repository.main.repository_url
+}
+
+output "ecr_repository_name" {
+  description = "ECR repository name — set as GitHub variable ECR_REPOSITORY_BT"
+  value       = aws_ecr_repository.main.name
+}
+
+output "ecr_repository_arn" {
+  description = "ARN of the ECR repository — referenced by the IAM module in the main stack"
+  value       = aws_ecr_repository.main.arn
+}

--- a/terraform/bootstrap/providers.tf
+++ b/terraform/bootstrap/providers.tf
@@ -1,0 +1,7 @@
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = local.common_tags
+  }
+}

--- a/terraform/bootstrap/terraform.tf
+++ b/terraform/bootstrap/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.10"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/terraform/bootstrap/terraform.tfvars.example
+++ b/terraform/bootstrap/terraform.tfvars.example
@@ -1,0 +1,4 @@
+aws_region        = "us-east-1"
+environment       = "staging"
+github_repository = "liatrio-forge/emerald-grove-pet-clinic-bota-tolepbergen"
+project_name      = "petclinic-bt"

--- a/terraform/bootstrap/variables.tf
+++ b/terraform/bootstrap/variables.tf
@@ -1,0 +1,23 @@
+variable "aws_region" {
+  type        = string
+  description = "AWS region for all resources"
+  default     = "us-east-1"
+}
+
+variable "environment" {
+  type        = string
+  description = "Deployment environment name"
+  default     = "staging"
+}
+
+variable "github_repository" {
+  type        = string
+  description = "GitHub repository in 'owner/repo' format for OIDC subject claim"
+  default     = "liatrio-forge/emerald-grove-pet-clinic-bota-tolepbergen"
+}
+
+variable "project_name" {
+  type        = string
+  description = "Project name used as prefix for all resources"
+  default     = "petclinic-bt"
+}

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,0 +1,25 @@
+locals {
+  name_prefix = "${var.project_name}-${var.environment}"
+
+  common_tags = {
+    Project     = var.project_name
+    Environment = var.environment
+    ManagedBy   = "terraform"
+  }
+
+  # Valid Fargate memory (MiB) per CPU value — per AWS ECS Fargate task size docs.
+  valid_fargate_memory = {
+    "256"  = [512, 1024, 2048]
+    "512"  = [1024, 2048, 3072, 4096]
+    "1024" = [2048, 3072, 4096, 5120, 6144, 7168, 8192]
+    "2048" = [4096, 5120, 6144, 7168, 8192, 9216, 10240, 11264, 12288, 13312, 14336, 15360, 16384]
+    "4096" = [8192, 9216, 10240, 11264, 12288, 13312, 14336, 15360, 16384, 17408, 18432, 19456, 20480, 21504, 22528, 23552, 24576, 25600, 26624, 27648, 28672, 29696, 30720]
+  }
+}
+
+check "fargate_cpu_memory_compatibility" {
+  assert {
+    condition     = contains(local.valid_fargate_memory[tostring(var.ecs_cpu)], var.ecs_memory)
+    error_message = "Invalid Fargate CPU/memory combination: cpu=${var.ecs_cpu}, memory=${var.ecs_memory} MiB. See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html for valid pairs."
+  }
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,73 @@
+module "networking" {
+  source = "./modules/networking"
+
+  name_prefix        = local.name_prefix
+  vpc_cidr           = var.vpc_cidr
+  availability_zones = var.availability_zones
+  tags               = local.common_tags
+}
+
+module "security" {
+  source = "./modules/security"
+
+  name_prefix    = local.name_prefix
+  vpc_id         = module.networking.vpc_id
+  container_port = var.container_port
+  tags           = local.common_tags
+}
+
+data "aws_ecr_repository" "main" {
+  name = local.name_prefix
+}
+
+module "iam" {
+  source = "./modules/iam"
+
+  name_prefix        = local.name_prefix
+  ecr_repository_arn = data.aws_ecr_repository.main.arn
+  db_secret_arn      = module.rds.db_secret_arn
+  tags               = local.common_tags
+}
+
+module "rds" {
+  source = "./modules/rds"
+
+  name_prefix       = local.name_prefix
+  subnet_ids        = module.networking.private_subnet_ids
+  security_group_id = module.security.rds_security_group_id
+  instance_class    = var.db_instance_class
+  tags              = local.common_tags
+}
+
+module "alb" {
+  source = "./modules/alb"
+
+  name_prefix       = local.name_prefix
+  vpc_id            = module.networking.vpc_id
+  public_subnet_ids = module.networking.public_subnet_ids
+  security_group_id = module.security.alb_security_group_id
+  container_port    = var.container_port
+  tags              = local.common_tags
+}
+
+module "ecs" {
+  source = "./modules/ecs"
+
+  name_prefix        = local.name_prefix
+  aws_region         = var.aws_region
+  container_image    = var.container_image
+  container_port     = var.container_port
+  cpu                = var.ecs_cpu
+  memory             = var.ecs_memory
+  desired_count      = var.desired_count
+  private_subnet_ids = module.networking.private_subnet_ids
+  security_group_id  = module.security.ecs_security_group_id
+  target_group_arn   = module.alb.target_group_arn
+  execution_role_arn = module.iam.task_execution_role_arn
+  task_role_arn      = module.iam.task_role_arn
+  rds_endpoint       = module.rds.db_endpoint
+  db_name            = module.rds.db_name
+  db_username        = module.rds.db_username
+  db_secret_arn      = module.rds.db_secret_arn
+  tags               = local.common_tags
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,9 +1,18 @@
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+locals {
+  # Use provided AZs, or fall back to the first two available in the region
+  resolved_azs = length(var.availability_zones) > 0 ? var.availability_zones : slice(data.aws_availability_zones.available.names, 0, 2)
+}
+
 module "networking" {
   source = "./modules/networking"
 
   name_prefix        = local.name_prefix
   vpc_cidr           = var.vpc_cidr
-  availability_zones = var.availability_zones
+  availability_zones = local.resolved_azs
   tags               = local.common_tags
 }
 

--- a/terraform/modules/alb/main.tf
+++ b/terraform/modules/alb/main.tf
@@ -1,0 +1,49 @@
+resource "aws_lb" "main" {
+  name                       = "${var.name_prefix}-alb"
+  internal                   = false
+  load_balancer_type         = "application"
+  security_groups            = [var.security_group_id]
+  subnets                    = var.public_subnet_ids
+  drop_invalid_header_fields = true
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-alb" })
+}
+
+resource "aws_lb_target_group" "main" {
+  name        = "${var.name_prefix}-tg"
+  port        = var.container_port
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+  target_type = "ip"
+
+  health_check {
+    path                = var.health_check_path
+    port                = "traffic-port"
+    healthy_threshold   = 3
+    unhealthy_threshold = 3
+    timeout             = 5
+    interval            = 30
+    matcher             = "200"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-tg" })
+}
+
+# HTTP-only listener: intentional for staging. For production, add an HTTPS
+# listener with an ACM certificate and redirect HTTP → HTTPS.
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.main.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.main.arn
+  }
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-listener-http" })
+}

--- a/terraform/modules/alb/outputs.tf
+++ b/terraform/modules/alb/outputs.tf
@@ -1,0 +1,14 @@
+output "alb_dns_name" {
+  description = "DNS name of the ALB"
+  value       = aws_lb.main.dns_name
+}
+
+output "alb_arn" {
+  description = "ARN of the ALB"
+  value       = aws_lb.main.arn
+}
+
+output "target_group_arn" {
+  description = "ARN of the target group"
+  value       = aws_lb_target_group.main.arn
+}

--- a/terraform/modules/alb/variables.tf
+++ b/terraform/modules/alb/variables.tf
@@ -1,0 +1,37 @@
+variable "container_port" {
+  type        = number
+  description = "Port the container listens on"
+  default     = 8080
+}
+
+variable "health_check_path" {
+  type        = string
+  description = "Health check path"
+  default     = "/actuator/health"
+}
+
+variable "name_prefix" {
+  type        = string
+  description = "Prefix for resource names"
+}
+
+variable "public_subnet_ids" {
+  type        = list(string)
+  description = "Public subnet IDs for the ALB"
+}
+
+variable "security_group_id" {
+  type        = string
+  description = "Security group ID for the ALB"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Common tags"
+  default     = {}
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "VPC ID"
+}

--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -1,0 +1,92 @@
+resource "aws_cloudwatch_log_group" "main" {
+  name              = "/ecs/${var.name_prefix}"
+  retention_in_days = 7
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-logs" })
+}
+
+resource "aws_ecs_cluster" "main" {
+  name = var.name_prefix
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}" })
+}
+
+resource "aws_ecs_task_definition" "main" {
+  family                   = var.name_prefix
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = var.cpu
+  memory                   = var.memory
+  execution_role_arn       = var.execution_role_arn
+  task_role_arn            = var.task_role_arn
+
+  container_definitions = jsonencode([{
+    name      = var.name_prefix
+    image     = var.container_image
+    essential = true
+
+    portMappings = [
+      {
+        containerPort = var.container_port
+        protocol      = "tcp"
+      }
+    ]
+
+    environment = [
+      { name = "SPRING_PROFILES_ACTIVE", value = "postgres" },
+      { name = "POSTGRES_URL", value = "jdbc:postgresql://${var.rds_endpoint}/${var.db_name}" },
+      { name = "POSTGRES_USER", value = var.db_username }
+    ]
+
+    secrets = [
+      { name = "POSTGRES_PASS", valueFrom = var.db_secret_arn }
+    ]
+
+    logConfiguration = {
+      logDriver = "awslogs"
+      options = {
+        "awslogs-group"         = aws_cloudwatch_log_group.main.name
+        "awslogs-region"        = var.aws_region
+        "awslogs-stream-prefix" = "ecs"
+      }
+    }
+
+    healthCheck = {
+      command     = ["CMD-SHELL", "curl -f http://localhost:${var.container_port}/actuator/health || exit 1"]
+      interval    = 30
+      timeout     = 5
+      retries     = 3
+      startPeriod = 60
+    }
+  }])
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-task" })
+}
+
+resource "aws_ecs_service" "main" {
+  name            = var.name_prefix
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.main.arn
+  desired_count   = var.desired_count
+  launch_type     = "FARGATE"
+
+  health_check_grace_period_seconds = var.health_check_grace_period
+
+  network_configuration {
+    subnets          = var.private_subnet_ids
+    security_groups  = [var.security_group_id]
+    assign_public_ip = false
+  }
+
+  load_balancer {
+    target_group_arn = var.target_group_arn
+    container_name   = var.name_prefix
+    container_port   = var.container_port
+  }
+
+  lifecycle {
+    ignore_changes = [task_definition]
+  }
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-service" })
+}

--- a/terraform/modules/ecs/outputs.tf
+++ b/terraform/modules/ecs/outputs.tf
@@ -1,0 +1,19 @@
+output "cluster_name" {
+  description = "Name of the ECS cluster"
+  value       = aws_ecs_cluster.main.name
+}
+
+output "service_name" {
+  description = "Name of the ECS service"
+  value       = aws_ecs_service.main.name
+}
+
+output "task_definition_arn" {
+  description = "ARN of the ECS task definition"
+  value       = aws_ecs_task_definition.main.arn
+}
+
+output "task_definition_family" {
+  description = "Family of the ECS task definition"
+  value       = aws_ecs_task_definition.main.family
+}

--- a/terraform/modules/ecs/variables.tf
+++ b/terraform/modules/ecs/variables.tf
@@ -1,0 +1,95 @@
+variable "aws_region" {
+  type        = string
+  description = "AWS region for CloudWatch logs"
+}
+
+variable "container_image" {
+  type        = string
+  description = "Docker image URI"
+}
+
+variable "container_port" {
+  type        = number
+  description = "Container port"
+  default     = 8080
+}
+
+variable "cpu" {
+  type        = number
+  description = "Fargate CPU units"
+  default     = 512
+}
+
+variable "db_name" {
+  type        = string
+  description = "Database name"
+}
+
+variable "db_secret_arn" {
+  type        = string
+  description = "Secrets Manager ARN for DB password"
+}
+
+variable "db_username" {
+  type        = string
+  description = "Database username"
+}
+
+variable "desired_count" {
+  type        = number
+  description = "Desired number of tasks"
+  default     = 1
+}
+
+variable "execution_role_arn" {
+  type        = string
+  description = "ECS task execution role ARN"
+}
+
+variable "health_check_grace_period" {
+  type        = number
+  description = "Health check grace period seconds"
+  default     = 120
+}
+
+variable "memory" {
+  type        = number
+  description = "Fargate memory in MiB"
+  default     = 1024
+}
+
+variable "name_prefix" {
+  type        = string
+  description = "Prefix for resource names"
+}
+
+variable "private_subnet_ids" {
+  type        = list(string)
+  description = "Private subnet IDs for ECS tasks"
+}
+
+variable "rds_endpoint" {
+  type        = string
+  description = "RDS endpoint (host:port)"
+}
+
+variable "security_group_id" {
+  type        = string
+  description = "Security group ID for ECS tasks"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Common tags"
+  default     = {}
+}
+
+variable "target_group_arn" {
+  type        = string
+  description = "ALB target group ARN"
+}
+
+variable "task_role_arn" {
+  type        = string
+  description = "ECS task role ARN"
+}

--- a/terraform/modules/iam/main.tf
+++ b/terraform/modules/iam/main.tf
@@ -1,0 +1,76 @@
+resource "aws_iam_role" "ecs_task_execution" {
+  name = "${var.name_prefix}-ecs-task-execution"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-ecs-task-execution" })
+}
+
+resource "aws_iam_role_policy" "ecs_task_execution" {
+  name = "${var.name_prefix}-ecs-task-execution-policy"
+  role = aws_iam_role.ecs_task_execution.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage"
+        ]
+        Resource = var.ecr_repository_arn
+      },
+      {
+        Effect   = "Allow"
+        Action   = "ecr:GetAuthorizationToken"
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = "arn:aws:logs:*:*:log-group:/ecs/${var.name_prefix}:*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = "secretsmanager:GetSecretValue"
+        Resource = var.db_secret_arn
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role" "ecs_task" {
+  name = "${var.name_prefix}-ecs-task"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-ecs-task" })
+}

--- a/terraform/modules/iam/outputs.tf
+++ b/terraform/modules/iam/outputs.tf
@@ -1,0 +1,9 @@
+output "task_execution_role_arn" {
+  description = "ARN of the ECS task execution IAM role"
+  value       = aws_iam_role.ecs_task_execution.arn
+}
+
+output "task_role_arn" {
+  description = "ARN of the ECS task IAM role"
+  value       = aws_iam_role.ecs_task.arn
+}

--- a/terraform/modules/iam/variables.tf
+++ b/terraform/modules/iam/variables.tf
@@ -1,0 +1,20 @@
+variable "db_secret_arn" {
+  type        = string
+  description = "ARN of the Secrets Manager secret for DB password"
+}
+
+variable "ecr_repository_arn" {
+  type        = string
+  description = "ARN of the ECR repository"
+}
+
+variable "name_prefix" {
+  type        = string
+  description = "Prefix for resource names"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Common tags"
+  default     = {}
+}

--- a/terraform/modules/networking/main.tf
+++ b/terraform/modules/networking/main.tf
@@ -1,0 +1,101 @@
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-vpc"
+  })
+}
+
+resource "aws_subnet" "public" {
+  for_each = toset(var.availability_zones)
+
+  vpc_id                  = aws_vpc.main.id
+  availability_zone       = each.key
+  cidr_block              = cidrsubnet(var.vpc_cidr, 8, index(var.availability_zones, each.key))
+  map_public_ip_on_launch = true
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-public-${each.key}"
+  })
+}
+
+resource "aws_subnet" "private" {
+  for_each = toset(var.availability_zones)
+
+  vpc_id            = aws_vpc.main.id
+  availability_zone = each.key
+  cidr_block        = cidrsubnet(var.vpc_cidr, 8, index(var.availability_zones, each.key) + 10)
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-private-${each.key}"
+  })
+}
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-igw"
+  })
+}
+
+resource "aws_eip" "nat" {
+  domain = "vpc"
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-nat-eip"
+  })
+}
+
+resource "aws_nat_gateway" "main" {
+  allocation_id = aws_eip.nat.id
+  subnet_id     = aws_subnet.public[var.availability_zones[0]].id
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-nat"
+  })
+
+  depends_on = [aws_internet_gateway.main]
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-public-rt"
+  })
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.main.id
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-private-rt"
+  })
+}
+
+resource "aws_route_table_association" "public" {
+  for_each = aws_subnet.public
+
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table_association" "private" {
+  for_each = aws_subnet.private
+
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.private.id
+}

--- a/terraform/modules/networking/outputs.tf
+++ b/terraform/modules/networking/outputs.tf
@@ -1,0 +1,14 @@
+output "vpc_id" {
+  description = "ID of the VPC"
+  value       = aws_vpc.main.id
+}
+
+output "public_subnet_ids" {
+  description = "List of public subnet IDs"
+  value       = values(aws_subnet.public)[*].id
+}
+
+output "private_subnet_ids" {
+  description = "List of private subnet IDs"
+  value       = values(aws_subnet.private)[*].id
+}

--- a/terraform/modules/networking/variables.tf
+++ b/terraform/modules/networking/variables.tf
@@ -1,0 +1,26 @@
+variable "availability_zones" {
+  type        = list(string)
+  description = "AZs to use"
+}
+
+variable "name_prefix" {
+  type        = string
+  description = "Prefix for resource names"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Common tags"
+  default     = {}
+}
+
+variable "vpc_cidr" {
+  type        = string
+  description = "CIDR block for VPC"
+  default     = "10.0.0.0/16"
+
+  validation {
+    condition     = can(cidrhost(var.vpc_cidr, 0))
+    error_message = "vpc_cidr must be a valid CIDR block (e.g. 10.0.0.0/16)."
+  }
+}

--- a/terraform/modules/rds/main.tf
+++ b/terraform/modules/rds/main.tf
@@ -26,10 +26,11 @@ resource "aws_db_instance" "main" {
   db_subnet_group_name   = aws_db_subnet_group.main.name
   vpc_security_group_ids = [var.security_group_id]
 
-  publicly_accessible = false
-  multi_az            = false
-  skip_final_snapshot = true
-  storage_encrypted   = true
+  publicly_accessible  = false
+  multi_az             = false
+  skip_final_snapshot  = true # Acceptable for staging; set to false for production
+  deletion_protection  = false # Set to true for production environments
+  storage_encrypted    = true
 
   tags = merge(var.tags, { Name = "${var.name_prefix}-db" })
 }

--- a/terraform/modules/rds/main.tf
+++ b/terraform/modules/rds/main.tf
@@ -1,0 +1,47 @@
+resource "random_password" "db" {
+  length           = 32
+  special          = true
+  override_special = "!#$%&*()-_=+[]{}<>:?"
+}
+
+resource "aws_db_subnet_group" "main" {
+  name       = "${var.name_prefix}-db"
+  subnet_ids = var.subnet_ids
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-db-subnet-group" })
+}
+
+resource "aws_db_instance" "main" {
+  identifier        = "${var.name_prefix}-db"
+  engine            = "postgres"
+  engine_version    = "17"
+  instance_class    = var.instance_class
+  allocated_storage = 20
+  storage_type      = "gp3"
+
+  db_name  = var.db_name
+  username = var.db_username
+  password = random_password.db.result
+
+  db_subnet_group_name   = aws_db_subnet_group.main.name
+  vpc_security_group_ids = [var.security_group_id]
+
+  publicly_accessible = false
+  multi_az            = false
+  skip_final_snapshot = true
+  storage_encrypted   = true
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-db" })
+}
+
+resource "aws_secretsmanager_secret" "db_password" {
+  name                    = "${var.name_prefix}/db-password"
+  recovery_window_in_days = 7
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-db-password" })
+}
+
+resource "aws_secretsmanager_secret_version" "db_password" {
+  secret_id     = aws_secretsmanager_secret.db_password.id
+  secret_string = random_password.db.result
+}

--- a/terraform/modules/rds/outputs.tf
+++ b/terraform/modules/rds/outputs.tf
@@ -1,0 +1,19 @@
+output "db_endpoint" {
+  description = "The connection endpoint for the RDS instance"
+  value       = aws_db_instance.main.endpoint
+}
+
+output "db_name" {
+  description = "The database name"
+  value       = aws_db_instance.main.db_name
+}
+
+output "db_username" {
+  description = "The master username for the database"
+  value       = aws_db_instance.main.username
+}
+
+output "db_secret_arn" {
+  description = "ARN of the Secrets Manager secret containing the DB password"
+  value       = aws_secretsmanager_secret.db_password.arn
+}

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -1,0 +1,38 @@
+variable "db_name" {
+  type        = string
+  description = "Database name"
+  default     = "petclinic"
+}
+
+variable "db_username" {
+  type        = string
+  description = "Database master username"
+  default     = "petclinic"
+}
+
+variable "instance_class" {
+  type        = string
+  description = "RDS instance class"
+  default     = "db.t3.micro"
+}
+
+variable "name_prefix" {
+  type        = string
+  description = "Prefix for resource names"
+}
+
+variable "security_group_id" {
+  type        = string
+  description = "Security group ID for the RDS instance"
+}
+
+variable "subnet_ids" {
+  type        = list(string)
+  description = "Subnet IDs for the DB subnet group"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Common tags"
+  default     = {}
+}

--- a/terraform/modules/security/main.tf
+++ b/terraform/modules/security/main.tf
@@ -1,0 +1,85 @@
+resource "aws_security_group" "alb" {
+  name        = "${var.name_prefix}-alb-sg"
+  description = "Security group for ALB"
+  vpc_id      = var.vpc_id
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-alb-sg"
+  })
+}
+
+resource "aws_vpc_security_group_ingress_rule" "alb_http" {
+  security_group_id = aws_security_group.alb.id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 80
+  to_port           = 80
+  ip_protocol       = "tcp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "alb_https" {
+  security_group_id = aws_security_group.alb.id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+}
+
+resource "aws_vpc_security_group_egress_rule" "alb_to_ecs" {
+  security_group_id            = aws_security_group.alb.id
+  referenced_security_group_id = aws_security_group.ecs.id
+  from_port                    = var.container_port
+  to_port                      = var.container_port
+  ip_protocol                  = "tcp"
+}
+
+resource "aws_security_group" "ecs" {
+  name        = "${var.name_prefix}-ecs-sg"
+  description = "Security group for ECS tasks"
+  vpc_id      = var.vpc_id
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-ecs-sg"
+  })
+}
+
+resource "aws_vpc_security_group_ingress_rule" "ecs_from_alb" {
+  security_group_id            = aws_security_group.ecs.id
+  referenced_security_group_id = aws_security_group.alb.id
+  from_port                    = var.container_port
+  to_port                      = var.container_port
+  ip_protocol                  = "tcp"
+}
+
+resource "aws_vpc_security_group_egress_rule" "ecs_to_rds" {
+  security_group_id            = aws_security_group.ecs.id
+  referenced_security_group_id = aws_security_group.rds.id
+  from_port                    = 5432
+  to_port                      = 5432
+  ip_protocol                  = "tcp"
+}
+
+resource "aws_vpc_security_group_egress_rule" "ecs_https_out" {
+  security_group_id = aws_security_group.ecs.id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+}
+
+resource "aws_security_group" "rds" {
+  name        = "${var.name_prefix}-rds-sg"
+  description = "Security group for RDS"
+  vpc_id      = var.vpc_id
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-rds-sg"
+  })
+}
+
+resource "aws_vpc_security_group_ingress_rule" "rds_from_ecs" {
+  security_group_id            = aws_security_group.rds.id
+  referenced_security_group_id = aws_security_group.ecs.id
+  from_port                    = 5432
+  to_port                      = 5432
+  ip_protocol                  = "tcp"
+}

--- a/terraform/modules/security/outputs.tf
+++ b/terraform/modules/security/outputs.tf
@@ -1,0 +1,14 @@
+output "alb_security_group_id" {
+  description = "ID of the ALB security group"
+  value       = aws_security_group.alb.id
+}
+
+output "ecs_security_group_id" {
+  description = "ID of the ECS security group"
+  value       = aws_security_group.ecs.id
+}
+
+output "rds_security_group_id" {
+  description = "ID of the RDS security group"
+  value       = aws_security_group.rds.id
+}

--- a/terraform/modules/security/variables.tf
+++ b/terraform/modules/security/variables.tf
@@ -1,0 +1,21 @@
+variable "container_port" {
+  type        = number
+  description = "Port the container listens on"
+  default     = 8080
+}
+
+variable "name_prefix" {
+  type        = string
+  description = "Prefix for resource names"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Common tags"
+  default     = {}
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "VPC ID"
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,24 @@
+output "app_url" {
+  description = "Public URL of the application (ALB DNS name)"
+  value       = "http://${module.alb.alb_dns_name}"
+}
+
+output "ecr_repository_url" {
+  description = "URL of the ECR repository for Docker images"
+  value       = data.aws_ecr_repository.main.repository_url
+}
+
+output "ecs_cluster_name" {
+  description = "Name of the ECS cluster"
+  value       = module.ecs.cluster_name
+}
+
+output "ecs_service_name" {
+  description = "Name of the ECS service"
+  value       = module.ecs.service_name
+}
+
+output "rds_endpoint" {
+  description = "RDS PostgreSQL connection endpoint"
+  value       = module.rds.db_endpoint
+}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,0 +1,7 @@
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = local.common_tags
+  }
+}

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = "~> 1.10"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,11 +1,11 @@
-project_name       = "petclinic"
+project_name       = "petclinic-bt"
 environment        = "staging"
 aws_region         = "us-east-1"
-availability_zones = ["us-east-1a", "us-east-1b"]
+availability_zones = ["us-east-1a", "us-east-1b"] # Must match aws_region
 vpc_cidr           = "10.0.0.0/16"
 db_instance_class  = "db.t3.micro"
 ecs_cpu            = 512
 ecs_memory         = 1024
-container_image    = "277802554323.dkr.ecr.us-east-1.amazonaws.com/petclinic-staging:<git-sha-or-release-tag>"
+container_image    = "277802554323.dkr.ecr.us-east-1.amazonaws.com/petclinic-bt-staging:<git-sha-or-release-tag>"
 container_port     = 8080
 desired_count      = 1

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,11 @@
+project_name       = "petclinic"
+environment        = "staging"
+aws_region         = "us-east-1"
+availability_zones = ["us-east-1a", "us-east-1b"]
+vpc_cidr           = "10.0.0.0/16"
+db_instance_class  = "db.t3.micro"
+ecs_cpu            = 512
+ecs_memory         = 1024
+container_image    = "277802554323.dkr.ecr.us-east-1.amazonaws.com/petclinic-staging:<git-sha-or-release-tag>"
+container_port     = 8080
+desired_count      = 1

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,7 +1,7 @@
 variable "availability_zones" {
   type        = list(string)
-  description = "List of availability zones to use"
-  default     = ["us-east-1a", "us-east-1b"]
+  description = "List of availability zones to use. Must be valid AZs in the chosen aws_region."
+  default     = []
 }
 
 variable "aws_region" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,99 @@
+variable "availability_zones" {
+  type        = list(string)
+  description = "List of availability zones to use"
+  default     = ["us-east-1a", "us-east-1b"]
+}
+
+variable "aws_region" {
+  type        = string
+  description = "AWS region for all resources"
+  default     = "us-east-1"
+}
+
+variable "container_image" {
+  type        = string
+  description = "Docker image URI for the application container"
+
+  validation {
+    condition     = length(var.container_image) > 0
+    error_message = "container_image must be a non-empty Docker image URI."
+  }
+}
+
+variable "container_port" {
+  type        = number
+  description = "Port the application container listens on"
+  default     = 8080
+
+  validation {
+    condition     = var.container_port >= 1 && var.container_port <= 65535
+    error_message = "container_port must be between 1 and 65535."
+  }
+}
+
+variable "db_instance_class" {
+  type        = string
+  description = "RDS instance class"
+  default     = "db.t3.micro"
+}
+
+variable "desired_count" {
+  type        = number
+  description = "Desired number of ECS tasks"
+  default     = 1
+
+  validation {
+    condition     = var.desired_count >= 0
+    error_message = "desired_count must be >= 0."
+  }
+}
+
+variable "ecs_cpu" {
+  type        = number
+  description = "Fargate CPU units for the ECS task"
+  default     = 512
+
+  validation {
+    condition     = contains([256, 512, 1024, 2048, 4096], var.ecs_cpu)
+    error_message = "ecs_cpu must be a supported Fargate value: 256, 512, 1024, 2048, or 4096."
+  }
+}
+
+variable "ecs_memory" {
+  type        = number
+  description = "Fargate memory (MiB) for the ECS task"
+  default     = 1024
+
+  validation {
+    condition     = contains([512, 1024, 2048, 3072, 4096, 5120, 6144, 7168, 8192, 16384, 30720], var.ecs_memory)
+    error_message = "ecs_memory must be a supported Fargate value (512–30720 MiB)."
+  }
+}
+
+variable "environment" {
+  type        = string
+  description = "Deployment environment name"
+  default     = "staging"
+
+  validation {
+    condition     = contains(["staging", "production"], var.environment)
+    error_message = "Environment must be 'staging' or 'production'."
+  }
+}
+
+variable "project_name" {
+  type        = string
+  description = "Project name used as prefix for all resources"
+  default     = "petclinic-bt"
+}
+
+variable "vpc_cidr" {
+  type        = string
+  description = "CIDR block for the VPC"
+  default     = "10.0.0.0/16"
+
+  validation {
+    condition     = can(cidrhost(var.vpc_cidr, 0))
+    error_message = "vpc_cidr must be a valid CIDR block (e.g. 10.0.0.0/16)."
+  }
+}


### PR DESCRIPTION
## Summary
- Add multi-stage Dockerfile (Maven build → JRE runtime) with health check on `/actuator/health`
- Add Terraform bootstrap (S3 state bucket, ECR repo, GitHub OIDC + IAM deploy role)
- Add Terraform main stack with 6 modules: networking (VPC/subnets), security (SGs), ALB, RDS PostgreSQL 17, IAM (ECS roles), ECS Fargate
- Add GitHub Actions: CI (build+test+Docker on PRs), deploy (CI→E2E→ECR→Terraform→ECS on merge to main), terraform (manual plan/apply/destroy)
- All resources use `petclinic-bt` prefix, secrets/vars use `_BT` suffix

## Test plan
- [ ] Bootstrap: `cd terraform/bootstrap && terraform init && terraform plan`
- [ ] Main stack: `cd terraform && terraform init && terraform plan`
- [ ] CI workflow: open a PR and verify checks run
- [ ] Deploy workflow: merge to main and verify ECS deployment
- [ ] Verify app accessible via ALB URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added CI/CD workflows for build/test, smoke Docker builds, deployment and Terraform orchestration.
  * Introduced a multi-stage Docker image for building and running the application.
  * Added comprehensive Terraform infrastructure: VPC, subnets, ALB, ECS/Fargate service, RDS (Postgres), ECR, IAM roles, security groups, provider config and state backend.
  * Included bootstrap tooling and example configs to initialize and migrate Terraform state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->